### PR TITLE
feat: add typescript rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ module.exports = {
       prefer: 'no-type-imports'
     }],
     '@typescript-eslint/no-empty-interface': 'off',
-    'no-unused-vars': ['off'],
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': 'off',
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = {
 
     '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
     '@typescript-eslint/comma-dangle': ['error', 'never'],
+    '@typescript-eslint/consistent-type-definitions': ['off'],
     '@typescript-eslint/consistent-type-imports': ['error', {
       prefer: 'no-type-imports'
     }],

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ module.exports = {
       prefer: 'no-type-imports'
     }],
     '@typescript-eslint/no-empty-interface': 'off',
+    'no-unused-vars': ['off'],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' }],
     '@typescript-eslint/no-use-before-define': 'off',
 
     'vue/attributes-order': 'off',

--- a/index.js
+++ b/index.js
@@ -41,14 +41,19 @@ module.exports = {
     }],
     'no-cond-assign': 'off',
 
-    '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
+    '@typescript-eslint/brace-style': ['error', '1tbs', {
+      allowSingleLine: true
+    }],
     '@typescript-eslint/comma-dangle': ['error', 'never'],
-    '@typescript-eslint/consistent-type-definitions': ['off'],
+    '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-imports': ['error', {
       prefer: 'no-type-imports'
     }],
     '@typescript-eslint/no-empty-interface': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      destructuredArrayIgnorePattern: '^_'
+    }],
     '@typescript-eslint/no-use-before-define': 'off',
 
     'vue/attributes-order': 'off',


### PR DESCRIPTION
以下のコメントに対応して、ルールを追加しました。

https://github.com/globalbrain/kadomony/pull/160#discussion_r1063253904

`Interface` と `type` の使い分けを可能にします。

https://github.com/globalbrain/kadomony/pull/160#discussion_r1063253066

`_` ではじまる変数名を使用しなくても、エラーにならないようにします。