### PR TITLE
feat(vue): allow v-bind string escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ module.exports = {
       capIsNew: false,
       properties: true
     }],
+    'n/prefer-global/process': 'off',
 
     '@typescript-eslint/brace-style': ['error', '1tbs', {
       allowSingleLine: true

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ module.exports = {
     'vue/custom-event-name-casing': ['error', 'kebab-case'],
     'vue/define-macros-order': 'off',
     'vue/html-closing-bracket-newline': 'off',
+    'vue/no-useless-v-bind': ['error', { ignoreStringEscape: true }],
     'vue/no-v-text-v-html-on-component': 'off',
     'vue/singleline-html-element-content-newline': 'off'
   }


### PR DESCRIPTION
closes #24

also disables `n/prefer-global/process` rule introduced in the underlying config.