### PR TITLE
fix: turn on `ignoreRestSiblings` for `no-unused-vars`

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ export default function globalbrain(...userConfigs) {
               'error',
               {
                 argsIgnorePattern: '^_',
-                destructuredArrayIgnorePattern: '^_'
+                destructuredArrayIgnorePattern: '^_',
+                ignoreRestSiblings: true
               }
             ]
           }


### PR DESCRIPTION
So that it won't error on code like

```
const { gray: _gray, ...rest } = chartColors
```

from:
https://github.com/globalbrain/sefirot/pull/657/files?new_files_changed=true&w=1#diff-21711022898132d802ee665fa41dd151e5a2c9ddf606f1cf32356a2eccc5f4d5R49

Note that this is a boolean option, not a pattern like `destructureArrayIgnorePattern` that can be limited to only those started with `_`, but I think it's acceptable.